### PR TITLE
accepts params to links endpoint

### DIFF
--- a/lib/sendgrid4r/rest/whitelabel/links.rb
+++ b/lib/sendgrid4r/rest/whitelabel/links.rb
@@ -103,7 +103,7 @@ module SendGrid4r
           ValidationResult.new(resp['valid'], resp['reason'])
         end
 
-       def get_wl_links(
+        def get_wl_links(
           limit: nil, offset: nil, exclude_subusers: nil, username: nil,
           domain: nil, &block
         )

--- a/lib/sendgrid4r/rest/whitelabel/links.rb
+++ b/lib/sendgrid4r/rest/whitelabel/links.rb
@@ -103,9 +103,20 @@ module SendGrid4r
           ValidationResult.new(resp['valid'], resp['reason'])
         end
 
-        def get_wl_links(&block)
+       def get_wl_links(
+          limit: nil, offset: nil, exclude_subusers: nil, username: nil,
+          domain: nil, &block
+        )
+          params = {}
+          params['limit'] = limit unless limit.nil?
+          params['offset'] = offset unless offset.nil?
+          unless exclude_subusers.nil?
+            params['exclude_subusers'] = exclude_subusers
+          end
+          params['username'] = username unless username.nil?
+          params['domain'] = domain unless domain.nil?
           endpoint = SendGrid4r::REST::Whitelabel::Links.url
-          resp = get(@auth, endpoint, nil, &block)
+          resp = get(@auth, endpoint, params, &block)
           SendGrid4r::REST::Whitelabel::Links.create_links(resp)
         end
 


### PR DESCRIPTION
Besides the documentation does not mention, the whitelabel/links endpoint accepts params like domain endpoint does: exclude_subusers, username etc..