### PR TITLE
Fix request rate limit - sleep method isn't happy with negative numbers

### DIFF
--- a/lib/sendgrid4r/rest/request.rb
+++ b/lib/sendgrid4r/rest/request.rb
@@ -39,7 +39,8 @@ module SendGrid4r
         return JSON.parse(body) unless body.nil? || body.length < 2
         body
       rescue RestClient::TooManyRequests => e
-        sleep e.response.headers[:x_ratelimit_reset].to_i - Time.now.to_i
+        duration = e.response.headers[:x_ratelimit_remaining].to_i
+        sleep duration if duration > 0
         retry
       end
 


### PR DESCRIPTION
Hi,

I got the following exception due to Sendgrid API requests rate limit :
```
ArgumentError: time interval must be positive
  from /home/michael/.../sendgrid4r-1.8.0/lib/sendgrid4r/rest/request.rb:42:in `sleep'
  from /home/michael/.../sendgrid4r-1.8.0/lib/sendgrid4r/rest/request.rb:42:in `rescue in execute'
  from /home/michael/.../sendgrid4r-1.8.0/lib/sendgrid4r/rest/request.rb:36:in `execute'
  from /home/michael/.../sendgrid4r-1.8.0/lib/sendgrid4r/rest/request.rb:20:in `post'
```

So here is the following fix.

Regards.