### PR TITLE
Relax rest-client version requirements

### DIFF
--- a/sendgrid4r.gemspec
+++ b/sendgrid4r.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency('rest-client', '>=1.8.0', '<1.9.0')
+  spec.add_dependency('rest-client', '>=1.8.0', '<3.0')
   spec.add_development_dependency('rubocop', '>=0.29.0', '<0.34.3')
   spec.add_development_dependency('bundler', '>=1.6.0', '<1.13.0')
   spec.add_development_dependency('rspec', '3.3.0')


### PR DESCRIPTION
rest-client version 2.0 was released recently: rest-client/rest-client@3a79728

Per the [upgrade notes](https://github.com/rest-client/rest-client/commit/51032140c9de747520278f1834156134944eb61b) and [history](https://github.com/rest-client/rest-client/blob/master/history.md#200), version 2.x is largely compatible API with version 1.x. This allows users of this gem to upgrade to rest-client version 2.0.