### PR TITLE
Add unique_arguments to EmailActivity response

### DIFF
--- a/lib/sendgrid4r/rest/email_activity.rb
+++ b/lib/sendgrid4r/rest/email_activity.rb
@@ -27,7 +27,7 @@ module SendGrid4r::REST
 
     Activity = Struct.new(
       :email, :event, :created, :category, :smtp_id, :asm_group_id,
-      :msg_id, :ip, :url, :reason
+      :msg_id, :ip, :url, :reason, :unique_arguments
     )
 
     def self.url
@@ -51,7 +51,8 @@ module SendGrid4r::REST
         resp['msg_id'],
         resp['ip'],
         resp['url'],
-        resp['reason']
+        resp['reason'],
+        resp['unique_arguments']
       )
     end
 


### PR DESCRIPTION
This PR adds`unique_arguments` field that was missing for EmailActivity.

API Response:

![screenshot 2016-12-12 17 37 26](https://cloud.githubusercontent.com/assets/818744/21113700/ba3382fa-c091-11e6-94f7-55e59da97da8.png)
